### PR TITLE
feat: adiciona Spring Actuator para endpoints de healthcheck

### DIFF
--- a/ACTUATOR_ENDPOINTS.md
+++ b/ACTUATOR_ENDPOINTS.md
@@ -1,0 +1,58 @@
+# Spring Actuator - Endpoints de Healthcheck
+
+Este documento descreve os endpoints do Spring Actuator disponíveis na API de Tênis do Belvedere.
+
+## Endpoints Disponíveis
+
+### 1. Health Check
+- **URL**: `GET /actuator/health`
+- **Descrição**: Verifica o status de saúde da aplicação
+- **Resposta**: Status UP/DOWN com detalhes dos componentes
+
+### 2. Informações da Aplicação
+- **URL**: `GET /actuator/info`
+- **Descrição**: Informações básicas sobre a aplicação
+- **Resposta**: Dados de build, versão, etc.
+
+### 3. Métricas
+- **URL**: `GET /actuator/metrics`
+- **Descrição**: Lista todas as métricas disponíveis
+- **Resposta**: Lista de métricas do sistema
+
+## Configuração
+
+Os endpoints estão configurados no arquivo `application.yml`:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+  health:
+    db:
+      enabled: true
+    diskspace:
+      enabled: true
+```
+
+## Segurança
+
+Todos os endpoints do Actuator (`/actuator/**`) estão configurados para acesso público, sem necessidade de autenticação, permitindo o uso em sistemas de monitoramento e healthcheck.
+
+## Exemplo de Uso
+
+```bash
+# Verificar status da aplicação
+curl http://localhost:8080/actuator/health
+
+# Obter informações da aplicação
+curl http://localhost:8080/actuator/info
+
+# Listar métricas disponíveis
+curl http://localhost:8080/actuator/metrics
+```

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 		</dependency>

--- a/src/main/java/br/com/belvedere/tenisapi/config/SecurityConfig.java
+++ b/src/main/java/br/com/belvedere/tenisapi/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(authz -> {
                 // 2. PERMITE AS REQUISIÇÕES PREFLIGHT (OPTIONS)
                 authz.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
+                // Permite acesso aos endpoints do Actuator para healthcheck
+                authz.requestMatchers("/actuator/**").permitAll();
                 // Lê as rotas do application.yaml e as libera
                 authz.requestMatchers(HttpMethod.GET, securityProperties.getPublicGetRoutes().toArray(new String[0])).permitAll();
                 authz.requestMatchers(HttpMethod.POST, securityProperties.getPublicPostRoutes().toArray(new String[0])).permitAll();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,22 @@ spring:
         format_sql: true
         default_schema: belvedere
 
+# Configuração do Spring Actuator
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+  health:
+    db:
+      enabled: true
+    diskspace:
+      enabled: true
+
 auth0:
   audience: https://belvedere.tenis.api
   #issuer-uri: https://dev-xvezaz1t34nrsh0d.us.auth0.com/ 


### PR DESCRIPTION
- Adiciona dependência spring-boot-starter-actuator no pom.xml
- Configura endpoints health, info e metrics no application.yml
- Libera acesso público aos endpoints /actuator/** no SecurityConfig
- Habilita monitoramento de banco de dados e espaço em disco
- Cria documentação dos endpoints disponíveis