### PR TITLE
feat: adiciona inicialização de dados e usuário admin inicial

### DIFF
--- a/src/main/java/br/com/belvedere/tenisapi/config/DataInitializer.java
+++ b/src/main/java/br/com/belvedere/tenisapi/config/DataInitializer.java
@@ -53,11 +53,11 @@ public class DataInitializer implements CommandLineRunner {
 
         // Admin
         User admin = new User();
-        admin.setName("Andre Muniz");
-        admin.setEmail("alnmuniz@gmail.com");
+        admin.setName("Luiza Vieira");
+        admin.setEmail("luizav@gmail.com");
         admin.setApartment("1102");
         admin.setRole(UserRole.ADMIN);
-        admin.setAuthProviderId("google-oauth2|118232728984586307358");
+        admin.setAuthProviderId("google-oauth2|12345644967464321654asdasdad");
         users.add(admin);
 
         // Usuários comuns

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -11,4 +11,5 @@
     <include file="db/changelog/scripts/003-enable-btree-gist-extension.xml"/>
     <include file="db/changelog/scripts/004-add-booking-exclusion-constraint.xml"/>
     <include file="db/changelog/scripts/005-add-status-to-users.xml"/>
+    <include file="db/changelog/scripts/006-insert-initial-admin.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/scripts/006-insert-initial-admin.xml
+++ b/src/main/resources/db/changelog/scripts/006-insert-initial-admin.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+                            
+    <changeSet id="6" author="alnmuniz">
+        <comment>Insere um usuário administrador inicial</comment>
+        <insert tableName="users" schemaName="belvedere">
+            <column name="name" value="Andre Muniz"/>
+            <column name="email" value="alnmuniz@gmail.com"/>
+            <column name="apartment" value="1102"/>
+            <column name="role" value="ADMIN"/>
+            <column name="status" value="ACTIVE"/>
+            <column name="auth_provider_id" value="google-oauth2|118232728984586307358"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>
+
+


### PR DESCRIPTION
- Adiciona DataInitializer com dados de teste completos (usuários e reservas)
- Cria script Liquibase para inserir usuário administrador inicial
- Atualiza changelog master para incluir novo script de migração
- Inclui dados de teste variados para desenvolvimento (reservas passadas, atuais e futuras)